### PR TITLE
Modified BeanEventType - call to FastClass.create()

### DIFF
--- a/esper/src/main/java/com/espertech/esper/event/bean/BeanEventType.java
+++ b/esper/src/main/java/com/espertech/esper/event/bean/BeanEventType.java
@@ -356,7 +356,7 @@ public class BeanEventType implements EventTypeSPI, NativeEventType
             fastClass = null;
             try
             {
-                fastClass = FastClass.create(Thread.currentThread().getContextClassLoader(), clazz);
+                fastClass = FastClass.create(clazz);
             }
             catch (Throwable ex)
             {


### PR DESCRIPTION
When used within an OSGi framework when BeanEventType.initialize() calls through to FastClass.create(ClassLoader, Class) can fail with 'ClassNotFoundException'. The class not found is FastClass itself, the exception being thrown in AbstractClassGenerator. I suspect this is due to the switching of ClassLoader to that specified in the call to FastClass.create() and currently the ClassLoader passed in is that of the current thread. Within OSGi this class loader may not have visibility of the net.sf.cglib.reflect.FastClass thus will cause the above exception.

The modification made in this commit uses the create() method which accepts only the class itself. Within FastClass it obtains the ClassLoader (from the class passed in) and because of this visibility of the FastClass method can be maintained provided the OSGi bundle containing the class passed to FastClass.create(Class) specifically imports the net.sf.cglib.reflect.FastClass.