### PR TITLE
import Module explicitly to disambiguate from java.lang.Module

### DIFF
--- a/regression-lib/src/main/java/com/espertech/esper/regressionlib/suite/client/compile/ClientCompileModuleUses.java
+++ b/regression-lib/src/main/java/com/espertech/esper/regressionlib/suite/client/compile/ClientCompileModuleUses.java
@@ -10,6 +10,7 @@
  */
 package com.espertech.esper.regressionlib.suite.client.compile;
 
+import com.espertech.esper.common.client.module.Module;
 import com.espertech.esper.common.client.module.*;
 import com.espertech.esper.common.client.scopetest.EPAssertionUtil;
 import com.espertech.esper.regressionlib.framework.RegressionEnvironment;


### PR DESCRIPTION
Java 9 added `java.lang.Module` which makes `com.espertech.esper.common.client.module.Module` ambiguous when imported with with a wildcard. An explicit import fixes this.