### PR TITLE
fix flaky tests on common module

### DIFF
--- a/common/src/test/java/com/espertech/esper/common/client/configuration/TestConfigurationParser.java
+++ b/common/src/test/java/com/espertech/esper/common/client/configuration/TestConfigurationParser.java
@@ -374,8 +374,8 @@ public class TestConfigurationParser extends TestCase {
         assertEquals(ThreadingProfile.LARGE, common.getExecution().getThreadingProfile());
 
         assertEquals(2, common.getEventTypeAutoNamePackages().size());
-        assertEquals("com.mycompany.eventsone", common.getEventTypeAutoNamePackages().toArray()[0]);
-        assertEquals("com.mycompany.eventstwo", common.getEventTypeAutoNamePackages().toArray()[1]);
+        assertTrue(common.getEventTypeAutoNamePackages().contains("com.mycompany.eventsone"));
+        assertTrue(common.getEventTypeAutoNamePackages().contains("com.mycompany.eventstwo")); 
 
         /*
          * COMPILER

--- a/common/src/test/java/com/espertech/esper/common/internal/supportunit/util/SupportJoinResultNodeFactory.java
+++ b/common/src/test/java/com/espertech/esper/common/internal/supportunit/util/SupportJoinResultNodeFactory.java
@@ -16,6 +16,7 @@ import com.espertech.esper.common.internal.support.SupportBean;
 import com.espertech.esper.common.internal.supportunit.event.SupportEventBeanFactory;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -43,7 +44,7 @@ public class SupportJoinResultNodeFactory {
         if (numObjects == 0) {
             return null;
         }
-        Set<EventBean> set = new HashSet<EventBean>();
+        Set<EventBean> set = new LinkedHashSet<EventBean>();
         for (int i = 0; i < numObjects; i++) {
             set.add(makeEvent());
         }


### PR DESCRIPTION
Addressed following flaky tests:
com.espertech.esper.common.client.configuration.TestConfiguration#testURL
com.espertech.esper.common.client.configuration.TestConfiguration#testFile
com.espertech.esper.common.internal.epl.join.assemble.TestLeafAssemblyNode#testProcess
com.espertech.esper.common.client.configuration.TestConfiguration#testString
com.espertech.esper.common.client.configuration.TestConfigurationParser#testRegressionFileConfig

Fixes:
Using LinkedHashSet to preserve order
Using set.contains() instead of set.toArray[idx]
