### PR TITLE
Fix flaky test

### DIFF
--- a/common/src/test/java/com/espertech/esper/common/internal/supportunit/util/SupportJoinResultNodeFactory.java
+++ b/common/src/test/java/com/espertech/esper/common/internal/supportunit/util/SupportJoinResultNodeFactory.java
@@ -16,6 +16,7 @@ import com.espertech.esper.common.internal.support.SupportBean;
 import com.espertech.esper.common.internal.supportunit.event.SupportEventBeanFactory;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -43,7 +44,7 @@ public class SupportJoinResultNodeFactory {
         if (numObjects == 0) {
             return null;
         }
-        Set<EventBean> set = new HashSet<EventBean>();
+        Set<EventBean> set = new LinkedHashSet<EventBean>();
         for (int i = 0; i < numObjects; i++) {
             set.add(makeEvent());
         }


### PR DESCRIPTION
`com.espertech.esper.common.internal.epl.join.assemble.TestLeafAssemblyNode#testProcess` test is flaky.
Line 38 from `TestLeafAssemblyNode.java`, `result[1].get(0).getEvents().iterator().next()`, could return the events in different order resulting in a test failure because`.iterator()` from a HashSet does not guarantee any order as per java docs (https://docs.oracle.com/javase/8/docs/api/java/util/HashSet.html). 

I've addressed this issue by using a `LinkedHashSet` instead of a `HashSet`.