### PR TITLE
fix 4 flaky tests

### DIFF
--- a/common/src/test/java/com/espertech/esper/common/client/configuration/TestConfigurationParser.java
+++ b/common/src/test/java/com/espertech/esper/common/client/configuration/TestConfigurationParser.java
@@ -374,8 +374,8 @@ public class TestConfigurationParser extends TestCase {
         assertEquals(ThreadingProfile.LARGE, common.getExecution().getThreadingProfile());
 
         assertEquals(2, common.getEventTypeAutoNamePackages().size());
-        assertEquals("com.mycompany.eventsone", common.getEventTypeAutoNamePackages().toArray()[0]);
-        assertEquals("com.mycompany.eventstwo", common.getEventTypeAutoNamePackages().toArray()[1]);
+        assertTrue(common.getEventTypeAutoNamePackages().contains("com.mycompany.eventsone"));
+        assertTrue(common.getEventTypeAutoNamePackages().contains("com.mycompany.eventstwo"));
 
         /*
          * COMPILER


### PR DESCRIPTION
The following tests are flaky:
`
com.espertech.esper.common.client.configuration.TestConfiguration#testURL
com.espertech.esper.common.client.configuration.TestConfiguration#testFile
com.espertech.esper.common.client.configuration.TestConfiguration#testString
com.espertech.esper.common.client.configuration.TestConfigurationParser#testRegressionFileConfig
`
There is no ordering guarantee for HashSet.toArray().

Similarly from lines 370 and 371 from the `TestConfigurationParser.java`, I've addressed this issue by using `HashSet.contains()`.