### PR TITLE
fix rfidAssetZone-TestLRMovingSimMain-testSim flaky test

### DIFF
--- a/examples/rfidassetzone/src/main/java/com/espertech/esper/example/rfidassetzone/LRMovingSimMain.java
+++ b/examples/rfidassetzone/src/main/java/com/espertech/esper/example/rfidassetzone/LRMovingSimMain.java
@@ -263,13 +263,6 @@ public class LRMovingSimMain implements Runnable {
         double deltaSeconds;
         int lastTotalEvents = 0;
         do {
-            // sleep
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                log.debug("Interrupted", e);
-                break;
-            }
             currTime = System.currentTimeMillis();
             deltaSeconds = (currTime - startTime) / 1000.0;
 
@@ -302,6 +295,13 @@ public class LRMovingSimMain implements Runnable {
                 for (int i = 0; i < callables.length; i++) {
                     callables[i].setGenerateZoneSplit(false);
                 }
+            }
+            // sleep
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                log.debug("Interrupted", e);
+                break;
             }
         }
         while (deltaSeconds < numSeconds);


### PR DESCRIPTION
observed flaky failures in ~10% of executions due to the generation of split zones due to random asset id generation. Moving sleep to after setGenerateZoneSplit call reduces flaky failures to ~0.02% (cased by other flaky faults)