### PR TITLE
finished fixing flaky test com.espertech.esper.regressionrun.suite.client.TestSuiteClientCompile.testClientCompileModule

### DIFF
--- a/regression-lib/src/main/java/com/espertech/esper/regressionlib/suite/client/compile/ClientCompileModule.java
+++ b/regression-lib/src/main/java/com/espertech/esper/regressionlib/suite/client/compile/ClientCompileModule.java
@@ -119,8 +119,8 @@ public class ClientCompileModule {
             moduleTwo.setUri("uri2");
             moduleTwo.setArchiveName("archive2");
             moduleTwo.setModuleUserObjectCompileTime("obj2");
-            moduleTwo.setUses(new HashSet<>(Arrays.asList("a", "b")));
-            moduleTwo.setImports(new HashSet<>(Arrays.asList("c", "d")));
+            moduleTwo.setUses(new LinkedHashSet<>(Arrays.asList("a", "b")));
+            moduleTwo.setImports(new LinkedHashSet<>(Arrays.asList("c", "d")));
             EPCompiled compiledTwo = env.compile(moduleTwo);
             env.deploy(compiledTwo);
 


### PR DESCRIPTION
# Test 1
## Changes proposed
Test```com.espertech.esper.regressionrun.suite.client.TestSuiteClientCompile.testClientCompileModule``` was found flaky by an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which will shuffle implementation-dependent operations. The error was thrown by: ```ClientCompileModuleTwoModules.run``` at line ```EPAssertionUtil.assertEqualsExactOrder("a,b".split(","), (String[]) infoTwo.getModuleProperties().get(ModuleProperty.USES));``` and ```EPAssertionUtil.assertEqualsExactOrder("c,d".split(","), (String[]) infoTwo.getModuleProperties().get(ModuleProperty.IMPORTS));```. The flakiness was resulted from the random order of the elements stored inside of the HashSet<String> in ```moduleTwo.setUses(new HashSet<>(Arrays.asList("a", "b")));``` and ```moduleTwo.setImports(new HashSet<>(Arrays.asList("c", "d")));```. The expected ```IMPORTS``` and ```USES``` used in the unit test was defined using strings with fixed order, and it will not match the the string arrays generated by ```(String[]) infoTwo.getModuleProperties().get(ModuleProperty.USES)``` and ```(String[]) infoTwo.getModuleProperties().get(ModuleProperty.IMPORTS)```; thus, the test will fail. The error messages:
```
junit.framework.AssertionFailedError: expected:<c> but was:<d>
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
        at com.espertech.esper.common.client.scopetest.ScopeTestHelper.fail(ScopeTestHelper.java:215)
        at com.espertech.esper.common.client.scopetest.ScopeTestHelper.failNotEquals(ScopeTestHelper.java:182)
        at com.espertech.esper.common.client.scopetest.ScopeTestHelper.assertEquals(ScopeTestHelper.java:78)
        at com.espertech.esper.common.client.scopetest.ScopeTestHelper.assertEquals(ScopeTestHelper.java:88)
        at com.espertech.esper.common.client.scopetest.EPAssertionUtil.assertEqualsExactOrder(EPAssertionUtil.java:291)
        at com.espertech.esper.regressionlib.suite.client.compile.ClientCompileModule$ClientCompileModuleTwoModules.run(ClientCompileModule.java:155)
        at com.espertech.esper.regressionrun.runner.RegressionRunner.run(RegressionRunner.java:77)
        at com.espertech.esper.regressionrun.runner.RegressionRunner.run(RegressionRunner.java:53)
        at com.espertech.esper.regressionrun.suite.client.TestSuiteClientCompile.testClientCompileModule(TestSuiteClientCompile.java:59)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at junit.framework.TestCase.runTest(TestCase.java:176)
        at junit.framework.TestCase.runBare(TestCase.java:141)
        at junit.framework.TestResult$1.protect(TestResult.java:122)
        at junit.framework.TestResult.runProtected(TestResult.java:142)
        at junit.framework.TestResult.run(TestResult.java:125)
        at junit.framework.TestCase.run(TestCase.java:129)
        at junit.framework.TestSuite.runTest(TestSuite.java:255)
        at junit.framework.TestSuite.run(TestSuite.java:250)
        at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:84)
        at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:62)
        at org.apache.maven.surefire.suite.AbstractDirectoryTestSuite.executeTestSet(AbstractDirectoryTestSuite.java:140)
        at org.apache.maven.surefire.suite.AbstractDirectoryTestSuite.execute(AbstractDirectoryTestSuite.java:127)
        at org.apache.maven.surefire.Surefire.run(Surefire.java:177)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.apache.maven.surefire.booter.SurefireBooter.runSuitesInProcess(SurefireBooter.java:345)
        at org.apache.maven.surefire.booter.SurefireBooter.main(SurefireBooter.java:1009)
```

## Fix of the problem
The fix was rather simple. I passed in two LinkedHashSet<String> instead of Set<String> when calling ```moduleTwo.setUses()``` and ```moduleTwo.setImports()```. The passed in LinkedHashSet<> can ensure the stored string values were sorted in alphabetical order. 

## Result of the fix
The test successed with Nondex runs for 3, 10, and 100 times. It can be safely concluded that the flakiness of this test is fixed

## Test Environment:
```
openjdk version "11.0.20.1"
Apache Maven 3.6.3
Ubuntu 20.04.6 LTS
Linux version: 5.4.0-163-generic
```