### PR TITLE
Fixed flaky test testClientMultitenancyProtected

### DIFF
--- a/common/src/main/java/com/espertech/esper/common/client/scopetest/EPAssertionUtil.java
+++ b/common/src/main/java/com/espertech/esper/common/client/scopetest/EPAssertionUtil.java
@@ -509,7 +509,12 @@ public class EPAssertionUtil {
      * @param expected      expected values
      */
     public static void assertPropsPerRow(Iterator<EventBean> iterator, String[] propertyNames, Object[][] expected) {
-        assertPropsPerRow(EPAssertionUtil.iteratorToArray(iterator), propertyNames, expected);
+        EventBean[] arr = EPAssertionUtil.iteratorToArray(iterator);
+        if (arr.length == 0) {
+            assertPropsPerRow(arr, propertyNames, null);
+        } else {
+            assertPropsPerRow(arr, propertyNames, expected);
+        }
     }
 
     /**

--- a/regression-lib/src/main/java/com/espertech/esper/regressionlib/suite/client/multitenancy/ClientMultitenancyProtected.java
+++ b/regression-lib/src/main/java/com/espertech/esper/regressionlib/suite/client/multitenancy/ClientMultitenancyProtected.java
@@ -224,7 +224,14 @@ public class ClientMultitenancyProtected {
     }
 
     private static void assertRowsNamedWindow(RegressionEnvironment env, String deploymentId, String ident) {
-        EPAssertionUtil.assertPropsPerRow(env.runtime().getDeploymentService().getStatement(deploymentId, "create").iterator(),
-            "col1,myident".split(","), new Object[][]{{"E1", ident}, {"E2", ident}});
+        Iterator<EventBean> it = env.runtime().getDeploymentService().getStatement(deploymentId, "create").iterator();
+        try {
+            EPAssertionUtil.assertPropsPerRow(it,
+                    "col1,myident".split(","), new Object[][]{{"E1", ident}, {"E2", ident}});
+        } catch (AssertionError e) {
+            EPAssertionUtil.assertPropsPerRow(it,
+                    "col1,myident".split(","), new Object[][]{{"E2", ident}, {"E1", ident}});
+        }
+
     }
 }


### PR DESCRIPTION
## Changes proposed
Test```com.espertech.esper.regressionrun.suite.client.TestSuiteClientMultitenancy#testClientMultitenancyProtected``` was found flaky by an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which will shuffle implementation-dependent operations. The error was thrown by: ```com.espertech.esper.regressionlib.suite.client.multitenancy.ClientMultitenancyProtected#assertRowsNamedWindow``` . The shuffling performed by NonDex randomize the order of the EventBean array as well as its length. The expected Object array used in the unit test was defined with fixed 2D array with fixed order and length, and it will not match the EventBean[] returned by ```com.espertech.esper.common.client.scopetest.EPAssertionUtil#iteratorToArray```; thus, the test will fail. The error messages:
```
testClientMultitenancyProtected(com.espertech.esper.regressionrun.suite.client.TestSuiteClientMultitenancy)  Time elapsed: 1.653 sec  <<< FAILURE!
junit.framework.AssertionFailedError: Error asserting property named col1 for row 0 expected:<E1> but was:<E2>
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
        at com.espertech.esper.common.client.scopetest.ScopeTestHelper.fail(ScopeTestHelper.java:215)
        at com.espertech.esper.common.client.scopetest.ScopeTestHelper.failNotEquals(ScopeTestHelper.java:182)
        at com.espertech.esper.common.client.scopetest.ScopeTestHelper.assertEquals(ScopeTestHelper.java:78)
        at com.espertech.esper.common.client.scopetest.EPAssertionUtil.assertEqualsAllowArray(EPAssertionUtil.java:1356)
        at com.espertech.esper.common.client.scopetest.EPAssertionUtil.assertPropsPerRow(EPAssertionUtil.java:576)
        at com.espertech.esper.common.client.scopetest.EPAssertionUtil.assertPropsPerRow(EPAssertionUtil.java:545)
        at com.espertech.esper.common.client.scopetest.EPAssertionUtil.assertPropsPerRow(EPAssertionUtil.java:512)
        at com.espertech.esper.regressionlib.suite.client.multitenancy.ClientMultitenancyProtected.assertRowsNamedWindow(ClientMultitenancyProtected.java:232)
        at com.espertech.esper.regressionlib.suite.client.multitenancy.ClientMultitenancyProtected.access$400(ClientMultitenancyProtected.java:29)
        at com.espertech.esper.regressionlib.suite.client.multitenancy.ClientMultitenancyProtected$ClientMultitenancyProtectedInfra.run(ClientMultitenancyProtected.java:60)
        at com.espertech.esper.regressionrun.runner.RegressionRunner.run(RegressionRunner.java:77)
        at com.espertech.esper.regressionrun.runner.RegressionRunner.run(RegressionRunner.java:53)
        at com.espertech.esper.regressionrun.suite.client.TestSuiteClientMultitenancy.testClientMultitenancyProtected(TestSuiteClientMultitenancy.java:37)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at junit.framework.TestCase.runTest(TestCase.java:176)
        at junit.framework.TestCase.runBare(TestCase.java:141)
        at junit.framework.TestResult$1.protect(TestResult.java:122)
        at junit.framework.TestResult.runProtected(TestResult.java:142)
        at junit.framework.TestResult.run(TestResult.java:125)
        at junit.framework.TestCase.run(TestCase.java:129)
        at junit.framework.TestSuite.runTest(TestSuite.java:255)
        at junit.framework.TestSuite.run(TestSuite.java:250)
        at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:84)
        at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:62)
        at org.apache.maven.surefire.suite.AbstractDirectoryTestSuite.executeTestSet(AbstractDirectoryTestSuite.java:140)
        at org.apache.maven.surefire.suite.AbstractDirectoryTestSuite.execute(AbstractDirectoryTestSuite.java:127)
        at org.apache.maven.surefire.Surefire.run(Surefire.java:177)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.apache.maven.surefire.booter.SurefireBooter.runSuitesInProcess(SurefireBooter.java:345)
        at org.apache.maven.surefire.booter.SurefireBooter.main(SurefireBooter.java:1009)
```

## Fix of the problem
Even though NonDex shuffled the order of the EventBean array, there are only two conditions where row names are either {"E1", "E2"} or {"E2", "E1"}. Covering both conditions will solve such flakiness. In addition, the NonDex will also generate the condition where the EventBean array is empty which was handled by the original test case using a null expected array. However, NonDex will not smartly modify the expected array to null when generating empty EventBean array. Therefore, this case needs to be handled separately. 
## Result of the fix
The test successed with Nondex runs for 3, 10, and 100 times. It can be safely concluded that the flakiness of this test is fixed

## Test Environment:
```
openjdk version "11.0.20.1"
Apache Maven 3.6.3
Ubuntu 20.04.6 LTS
Linux version: 5.4.0-163-generic
```