### PR TITLE
Sorted the EventBean array to fix 5 flaky tests

### DIFF
--- a/common/src/main/java/com/espertech/esper/common/client/scopetest/EPAssertionUtil.java
+++ b/common/src/main/java/com/espertech/esper/common/client/scopetest/EPAssertionUtil.java
@@ -568,16 +568,7 @@ public class EPAssertionUtil {
             return lastElement1.compareTo(lastElement2);
         };
         Arrays.sort(expected, lastElementComparator);
-
-        Comparator<EventBean> eventBeanComparator = (bean1, bean2) -> {
-            Comparable value1 = (Comparable) bean1.get(propertyNames[propertyNames.length - 1]);
-            Comparable value2 = (Comparable) bean2.get(propertyNames[propertyNames.length - 1]);
-            if (value1 == null) return (value2 == null) ? 0 : 1;
-            if (value2 == null) return -1;
-            return value1.compareTo(value2);
-        };
-        Arrays.sort(actual, eventBeanComparator);
-
+        actual = sort(actual, propertyNames[propertyNames.length - 1]);
         for (int i = 0; i < expected.length; i++) {
             Object[] propertiesThisRow = expected[i];
             ScopeTestHelper.assertEquals("Number of properties expected mismatches for row " + i, propertyNames.length, propertiesThisRow.length);

--- a/common/src/main/java/com/espertech/esper/common/client/scopetest/EPAssertionUtil.java
+++ b/common/src/main/java/com/espertech/esper/common/client/scopetest/EPAssertionUtil.java
@@ -557,18 +557,29 @@ public class EPAssertionUtil {
         if (compareArraySize(expected, actual)) {
             return;
         }
-        Comparator<Object[]> lastElementComparator = (row1, row2) -> {
-            if (row1.length == 0 && row2.length == 0) return 0;
-            if (row1.length == 0) return -1;
-            if (row2.length == 0) return 1;
-            Comparable lastElement1 = (Comparable) row1[row1.length - 1];
-            Comparable lastElement2 = (Comparable) row2[row2.length - 1];
-            if (lastElement1 == null) return (lastElement2 == null) ? 0 : 1;
-            if (lastElement2 == null) return -1;
-            return lastElement1.compareTo(lastElement2);
-        };
-        Arrays.sort(expected, lastElementComparator);
-        actual = sort(actual, propertyNames[propertyNames.length - 1]);
+        if (expected.length > 1) {
+            int sortIndex = propertyNames.length - 1;
+            for (int i = 0; i < propertyNames.length; i++) {
+                if (!expected[0][i].equals(expected[1][i])) {
+                    sortIndex = i;
+                    break;
+                }
+            }
+            final int finalSortIndex = sortIndex;
+            Comparator<Object[]> lastElementComparator = (row1, row2) -> {
+                if (row1.length == 0 && row2.length == 0) return 0;
+                if (row1.length == 0) return -1;
+                if (row2.length == 0) return 1;
+                Comparable lastElement1 = (Comparable) row1[finalSortIndex];
+                Comparable lastElement2 = (Comparable) row2[finalSortIndex];
+                if (lastElement1 == null) return (lastElement2 == null) ? 0 : 1;
+                if (lastElement2 == null) return -1;
+                return lastElement1.compareTo(lastElement2);
+            };
+            Arrays.sort(expected, lastElementComparator);
+            sort(actual, propertyNames[finalSortIndex]);
+        }
+
         for (int i = 0; i < expected.length; i++) {
             Object[] propertiesThisRow = expected[i];
             ScopeTestHelper.assertEquals("Number of properties expected mismatches for row " + i, propertyNames.length, propertiesThisRow.length);

--- a/common/src/main/java/com/espertech/esper/common/client/scopetest/EPAssertionUtil.java
+++ b/common/src/main/java/com/espertech/esper/common/client/scopetest/EPAssertionUtil.java
@@ -557,6 +557,27 @@ public class EPAssertionUtil {
         if (compareArraySize(expected, actual)) {
             return;
         }
+        Comparator<Object[]> lastElementComparator = (row1, row2) -> {
+            if (row1.length == 0 && row2.length == 0) return 0;
+            if (row1.length == 0) return -1;
+            if (row2.length == 0) return 1;
+            Comparable lastElement1 = (Comparable) row1[row1.length - 1];
+            Comparable lastElement2 = (Comparable) row2[row2.length - 1];
+            if (lastElement1 == null) return (lastElement2 == null) ? 0 : 1;
+            if (lastElement2 == null) return -1;
+            return lastElement1.compareTo(lastElement2);
+        };
+        Arrays.sort(expected, lastElementComparator);
+
+        Comparator<EventBean> eventBeanComparator = (bean1, bean2) -> {
+            Comparable value1 = (Comparable) bean1.get(propertyNames[propertyNames.length - 1]);
+            Comparable value2 = (Comparable) bean2.get(propertyNames[propertyNames.length - 1]);
+            if (value1 == null) return (value2 == null) ? 0 : 1;
+            if (value2 == null) return -1;
+            return value1.compareTo(value2);
+        };
+        Arrays.sort(actual, eventBeanComparator);
+
         for (int i = 0; i < expected.length; i++) {
             Object[] propertiesThisRow = expected[i];
             ScopeTestHelper.assertEquals("Number of properties expected mismatches for row " + i, propertyNames.length, propertiesThisRow.length);


### PR DESCRIPTION
# Flaky tests: 
There were 5 flaky tests all due to the same issue found by an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which will shuffle implementation-dependent operations. All of them are due to the problems that the passed in ```EventBean[]``` by ```com.espertech.esper.common.client.scopetest.EPAssertionUtil#assertPropsPerRow(EventBean[], String[], Object[][], String)``` has nondeterministic orders. However, the expected ```Object[][]``` was defined with hard coded order. Therefore, they won't match durig NonDex shuffling. 
## Test 1: com.espertech.esper.regressionrun.suite.client.TestSuiteClientMultitenancy.testClientMultitenancyProtected
## Test 2: com.espertech.esper.regressionrun.suite.context.TestSuiteContext.testContextInitTerm
## Test 3: com.espertech.esper.regressionrun.suite.context.TestSuiteContext.testContextKeySegmented
## Test 4: com.espertech.esper.regressionrun.suite.context.TestSuiteContext.testContextSelectionAndFireAndForget
## Test 5: com.espertech.esper.regressionrun.suite.context.TestSuiteContext.testContextVariables
They all have similar test failure stack trace: 
The error messages:
```
testClientMultitenancyProtected(com.espertech.esper.regressionrun.suite.client.TestSuiteClientMultitenancy)  Time elapsed: 1.653 sec  <<< FAILURE!
junit.framework.AssertionFailedError: Error asserting property named col1 for row 0 expected:<E1> but was:<E2>
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
        at com.espertech.esper.common.client.scopetest.ScopeTestHelper.fail(ScopeTestHelper.java:215)
        at com.espertech.esper.common.client.scopetest.ScopeTestHelper.failNotEquals(ScopeTestHelper.java:182)
        at com.espertech.esper.common.client.scopetest.ScopeTestHelper.assertEquals(ScopeTestHelper.java:78)
        at com.espertech.esper.common.client.scopetest.EPAssertionUtil.assertEqualsAllowArray(EPAssertionUtil.java:1356)
        at com.espertech.esper.common.client.scopetest.EPAssertionUtil.assertPropsPerRow(EPAssertionUtil.java:576)
        at com.espertech.esper.common.client.scopetest.EPAssertionUtil.assertPropsPerRow(EPAssertionUtil.java:545)
        at com.espertech.esper.common.client.scopetest.EPAssertionUtil.assertPropsPerRow(EPAssertionUtil.java:512)
        at com.espertech.esper.regressionlib.suite.client.multitenancy.ClientMultitenancyProtected.assertRowsNamedWindow(ClientMultitenancyProtected.java:232)
        at com.espertech.esper.regressionlib.suite.client.multitenancy.ClientMultitenancyProtected.access$400(ClientMultitenancyProtected.java:29)
        at com.espertech.esper.regressionlib.suite.client.multitenancy.ClientMultitenancyProtected$ClientMultitenancyProtectedInfra.run(ClientMultitenancyProtected.java:60)
        at com.espertech.esper.regressionrun.runner.RegressionRunner.run(RegressionRunner.java:77)
        at com.espertech.esper.regressionrun.runner.RegressionRunner.run(RegressionRunner.java:53)
        at com.espertech.esper.regressionrun.suite.client.TestSuiteClientMultitenancy.testClientMultitenancyProtected(TestSuiteClientMultitenancy.java:37)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at junit.framework.TestCase.runTest(TestCase.java:176)
        at junit.framework.TestCase.runBare(TestCase.java:141)
        at junit.framework.TestResult$1.protect(TestResult.java:122)
        at junit.framework.TestResult.runProtected(TestResult.java:142)
        at junit.framework.TestResult.run(TestResult.java:125)
        at junit.framework.TestCase.run(TestCase.java:129)
        at junit.framework.TestSuite.runTest(TestSuite.java:255)
        at junit.framework.TestSuite.run(TestSuite.java:250)
        at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:84)
        at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:62)
        at org.apache.maven.surefire.suite.AbstractDirectoryTestSuite.executeTestSet(AbstractDirectoryTestSuite.java:140)
        at org.apache.maven.surefire.suite.AbstractDirectoryTestSuite.execute(AbstractDirectoryTestSuite.java:127)
        at org.apache.maven.surefire.Surefire.run(Surefire.java:177)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.apache.maven.surefire.booter.SurefireBooter.runSuitesInProcess(SurefireBooter.java:345)
        at org.apache.maven.surefire.booter.SurefireBooter.main(SurefireBooter.java:1009)
```

## Fix of the problem
All of these tests will call ```com.espertech.esper.common.client.scopetest.EPAssertionUtil#assertPropsPerRow(EventBean[], String[], Object[][], String)``` to check the order and content within the ```EventBean[]```. I implemented a customized Comparator to sort the ```Object[][] expected```. The sorting creterion will vary based on column that varies in each row. Then, I implemented the built-in ```com.espertech.esper.common.client.scopetest.EPAssertionUtil#sort(EventBean[], String)``` method to sort the actual array using the same sorting creterion. 
## Result of the fix
The test successed with Nondex runs for 3, 10, and 100 times. It can be safely concluded that the flakiness of this test is fixed

## Test Environment:
```
openjdk version "11.0.20.1"
Apache Maven 3.6.3
Ubuntu 20.04.6 LTS
Linux version: 5.4.0-163-generic
```